### PR TITLE
Skip product/api validation if entries not present in the yaml file

### DIFF
--- a/src/Kmd.Logic.Gateway.Automation/PreValidation/ApisPreValidation.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PreValidation/ApisPreValidation.cs
@@ -14,7 +14,7 @@ namespace Kmd.Logic.Gateway.Automation.PreValidation
 
         public IEnumerable<GatewayAutomationResult> ValidateAsync(PublishFileModel publishFileModel)
         {
-            if (publishFileModel != null && publishFileModel.Apis != null && publishFileModel.Apis.Any())
+            if (publishFileModel != null && publishFileModel.Apis.Any())
             {
                 var duplicateApis = publishFileModel.Apis.GroupBy(x => x.Name).Any(x => x.Count() > 1);
                 if (duplicateApis)

--- a/src/Kmd.Logic.Gateway.Automation/PreValidation/ApisPreValidation.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PreValidation/ApisPreValidation.cs
@@ -14,7 +14,7 @@ namespace Kmd.Logic.Gateway.Automation.PreValidation
 
         public IEnumerable<GatewayAutomationResult> ValidateAsync(PublishFileModel publishFileModel)
         {
-            if (publishFileModel != null)
+            if (publishFileModel != null && publishFileModel.Apis != null && publishFileModel.Apis.Any())
             {
                 var duplicateApis = publishFileModel.Apis.GroupBy(x => x.Name).Any(x => x.Count() > 1);
                 if (duplicateApis)

--- a/src/Kmd.Logic.Gateway.Automation/PreValidation/ProductsPreValidation.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PreValidation/ProductsPreValidation.cs
@@ -13,7 +13,7 @@ namespace Kmd.Logic.Gateway.Automation.PreValidation
 
         public IEnumerable<GatewayAutomationResult> ValidateAsync(PublishFileModel publishFileModel)
         {
-            if (publishFileModel != null)
+            if (publishFileModel != null && publishFileModel.Products != null && publishFileModel.Products.Any())
             {
                 var duplicateProducts = publishFileModel.Products.GroupBy(x => x.Name).Any(x => x.Count() > 1);
                 if (duplicateProducts)

--- a/src/Kmd.Logic.Gateway.Automation/PreValidation/ProductsPreValidation.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PreValidation/ProductsPreValidation.cs
@@ -13,7 +13,7 @@ namespace Kmd.Logic.Gateway.Automation.PreValidation
 
         public IEnumerable<GatewayAutomationResult> ValidateAsync(PublishFileModel publishFileModel)
         {
-            if (publishFileModel != null && publishFileModel.Products != null && publishFileModel.Products.Any())
+            if (publishFileModel != null && publishFileModel.Products.Any())
             {
                 var duplicateProducts = publishFileModel.Products.GroupBy(x => x.Name).Any(x => x.Count() > 1);
                 if (duplicateProducts)

--- a/src/Kmd.Logic.Gateway.Automation/PublishFile/PublishFileModel.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PublishFile/PublishFileModel.cs
@@ -4,8 +4,20 @@ namespace Kmd.Logic.Gateway.Automation.PublishFile
 {
     internal class PublishFileModel
     {
-        public IEnumerable<Product> Products { get; set; } = new List<Product>();
+        private IEnumerable<Product> products;
 
-        public IEnumerable<Api> Apis { get; set; } = new List<Api>();
+        public IEnumerable<Product> Products
+        {
+            get { return this.products ?? new List<Product>(); }
+            set { this.products = value; }
+        }
+
+        private IEnumerable<Api> apis;
+
+        public IEnumerable<Api> Apis
+        {
+            get { return this.apis ?? new List<Api>(); }
+            set { this.apis = value; }
+        }
     }
 }

--- a/src/Kmd.Logic.Gateway.Automation/PublishFile/PublishFileModel.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PublishFile/PublishFileModel.cs
@@ -4,8 +4,8 @@ namespace Kmd.Logic.Gateway.Automation.PublishFile
 {
     internal class PublishFileModel
     {
-        public IEnumerable<Product> Products { get; set; }
+        public IEnumerable<Product> Products { get; set; } = new List<Product>();
 
-        public IEnumerable<Api> Apis { get; set; }
+        public IEnumerable<Api> Apis { get; set; } = new List<Api>();
     }
 }

--- a/src/Kmd.Logic.Gateway.Automation/ValidatePublishing.cs
+++ b/src/Kmd.Logic.Gateway.Automation/ValidatePublishing.cs
@@ -28,6 +28,19 @@ namespace Kmd.Logic.Gateway.Automation
             var publishYml = File.ReadAllText(Path.Combine(folderPath, "publish.yml"));
             var publishFileModel = new Deserializer().Deserialize<PublishFileModel>(publishYml);
 
+            if (publishFileModel != null && !publishFileModel.Products.Any() && !publishFileModel.Apis.Any())
+            {
+                return new ValidationResult(new List<GatewayAutomationResult>()
+                {
+                    new GatewayAutomationResult
+                    {
+                        IsError = true,
+                        ResultCode = ResultCode.ValidationFailed,
+                        Message = $"Both products and apis are empty in the file. Nothing to validate/publish",
+                    },
+                });
+            }
+
             var preValidationsResults = PreValidateEntities(folderPath, publishFileModel);
             if (preValidationsResults.Any(r => r.IsError))
             {


### PR DESCRIPTION
Following are the changes

- Made products/api collections return empty lists if null, to avoid null checks in multiple places
- Skip product pre-validation if products are not present in the file
- Skip api pre-validation if apis are not present in the file
- Handle files with both products and apis empty