### PR TITLE
Bugfix - Added support for MarkAsCurrent of API Versions

### DIFF
--- a/sample/Kmd.Logic.Gateway.Automation.Sample/Publish/publish.yml
+++ b/sample/Kmd.Logic.Gateway.Automation.Sample/Publish/publish.yml
@@ -30,7 +30,7 @@ Apis:
       ProductNames: [nexus-1]
       PolicyXmlFile: ./apis/nexus/policies.xml
       BackendLocation: http://nexus
-      IsCurrent: true
+      IsCurrent: false
       Revisions:
        - RevisionDescription: Rev2
          OpenApiSpecFile: ./apis/nexus/v1/nexus-r2.json

--- a/sample/Kmd.Logic.Gateway.Automation.Sample/Publish/publish.yml
+++ b/sample/Kmd.Logic.Gateway.Automation.Sample/Publish/publish.yml
@@ -30,6 +30,7 @@ Apis:
       ProductNames: [nexus-1]
       PolicyXmlFile: ./apis/nexus/policies.xml
       BackendLocation: http://nexus
+      IsCurrent: true
       Revisions:
        - RevisionDescription: Rev2
          OpenApiSpecFile: ./apis/nexus/v1/nexus-r2.json
@@ -42,6 +43,7 @@ Apis:
       ProductNames: [nexus-1]
       PolicyXmlFile: ./apis/nexus/policies.xml
       BackendLocation: http://nexus
+      IsCurrent: true
       Revisions:
        - RevisionDescription: Rev2
          OpenApiSpecFile: ./apis/nexus/v2/nexus-r2.json
@@ -58,6 +60,7 @@ Apis:
       PolicyXmlFile: ./apis/nexus2/policies.xml
       BackendLocation: http://nexus2
       Status: Active
+      IsCurrent: true
       Revisions:
        - RevisionDescription: Rev2
          OpenApiSpecFile: ./apis/nexus2/v1/nexus-r2.json
@@ -73,5 +76,6 @@ Apis:
       ProductNames: [nexus-2]
       PolicyXmlFile: ./apis/nexus3/policies.xml
       BackendLocation: http://nexus3
+      IsCurrent: true
       Status: Preview
    Path: nexus3

--- a/src/Kmd.Logic.Gateway.Automation/Client/Extensions/GatewayClient.ApiExtensions.cs
+++ b/src/Kmd.Logic.Gateway.Automation/Client/Extensions/GatewayClient.ApiExtensions.cs
@@ -48,7 +48,7 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Can't address. Has implications!!")]
         private async Task<HttpOperationResponse<object>> CustomCreateApiWithHttpMessagesAsync(System.Guid subscriptionId, string name, string path, string apiVersion, Stream openApiSpec, System.Guid? apiVersionSetId = default(System.Guid?), string providerId = default(string), string visibility = default(string), string backendServiceUrl = default(string), IList<System.Guid?> productIds = default(IList<System.Guid?>), Stream logo = default(Stream), Stream documentation = default(Stream), string status = default(string), bool? isCurrent = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            ValidateRequest(name, path, apiVersion, openApiSpec);
+            ValidateRequest(name, path, apiVersion, openApiSpec, isCurrent);
 
             // Tracing
             bool shouldTrace = ServiceClientTracing.IsEnabled;
@@ -361,7 +361,7 @@
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Not addressing for the sake of readability")]
-        private static void ValidateRequest(string name, string path, string apiVersion, Stream openApiSpec)
+        private static void ValidateRequest(string name, string path, string apiVersion, Stream openApiSpec, bool? isCurrent)
         {
             if (name == null)
             {
@@ -381,6 +381,11 @@
             if (openApiSpec == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "openApiSpec");
+            }
+
+            if (!isCurrent.HasValue)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "isCurrent");
             }
         }
 

--- a/src/Kmd.Logic.Gateway.Automation/GatewayAutomationResult.cs
+++ b/src/Kmd.Logic.Gateway.Automation/GatewayAutomationResult.cs
@@ -21,11 +21,6 @@ namespace Kmd.Logic.Gateway.Automation
                 return $"Error Code: {this.ResultCode}, Message: {this.Message}{entityMessage}";
             }
 
-            if (string.IsNullOrEmpty(this.Message))
-            {
-                return $"Result Code: {this.ResultCode}, Message: {entityMessage}";
-            }
-
             return $"Result Code: {this.ResultCode}{entityMessage}";
         }
     }

--- a/src/Kmd.Logic.Gateway.Automation/PreValidation/ApisPreValidation.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PreValidation/ApisPreValidation.cs
@@ -37,10 +37,19 @@ namespace Kmd.Logic.Gateway.Automation.PreValidation
 
                 foreach (var api in publishFileModel.Apis)
                 {
+                    var apiPrefix = $"API: {api.Name}, {api.Path}";
+
                     if (api.ApiVersions == null)
                     {
                         this.ValidationResults.Add(new GatewayAutomationResult { IsError = true, ResultCode = ResultCode.ValidationFailed, Message = $"Version shouldn't be null" });
                         continue;
+                    }
+
+                    if (api.ApiVersions
+                            .Where(v => v.IsCurrent.HasValue)
+                            .Count(v => v.IsCurrent == true) != 1)
+                    {
+                        this.ValidationResults.Add(new GatewayAutomationResult { IsError = true, ResultCode = ResultCode.ValidationFailed, Message = $"[{apiPrefix}] Only one Version must be set as current" });
                     }
 
                     foreach (var version in api.ApiVersions)
@@ -54,7 +63,6 @@ namespace Kmd.Logic.Gateway.Automation.PreValidation
                         }
                     }
 
-                    var apiPrefix = $"API: {api.Name}, {api.Path}";
                     var duplicateVersions = api.ApiVersions.GroupBy(x => x.VersionName).Any(x => x.Count() > 1);
                     if (duplicateVersions)
                     {
@@ -82,6 +90,11 @@ namespace Kmd.Logic.Gateway.Automation.PreValidation
                         if (string.IsNullOrEmpty(version.BackendLocation) || !Uri.IsWellFormedUriString(version.BackendLocation, UriKind.Absolute))
                         {
                             this.ValidationResults.Add(new GatewayAutomationResult { IsError = true, ResultCode = ResultCode.ValidationFailed, Message = $"[{apiVersionPrefix}] {nameof(version.BackendLocation)} does not exist or not valid uri format" });
+                        }
+
+                        if (!version.IsCurrent.HasValue)
+                        {
+                            this.ValidationResults.Add(new GatewayAutomationResult { IsError = true, ResultCode = ResultCode.ValidationFailed, Message = $"[{apiVersionPrefix}] {nameof(version.IsCurrent)} is not specified" });
                         }
 
                         this.ValidateFile(FileType.PolicyXml, version.PolicyXmlFile, apiVersionPrefix, nameof(version.PolicyXmlFile));

--- a/src/Kmd.Logic.Gateway.Automation/PublishFile/ApiVersion.cs
+++ b/src/Kmd.Logic.Gateway.Automation/PublishFile/ApiVersion.cs
@@ -25,5 +25,7 @@ namespace Kmd.Logic.Gateway.Automation.PublishFile
         public string Visibility { get; set; }
 
         public ApiStatus? Status { get; set; }
+
+        public bool? IsCurrent { get; set; }
     }
 }

--- a/src/Kmd.Logic.Gateway.Automation/ResultCode.cs
+++ b/src/Kmd.Logic.Gateway.Automation/ResultCode.cs
@@ -28,6 +28,11 @@
         ApiUpdated,
 
         /// <summary>
+        /// Api version marked as current.
+        /// </summary>
+        ApiVersionMarkedAsCurrent,
+
+        /// <summary>
         /// Version created successfully.
         /// </summary>
         VersionCreated,


### PR DESCRIPTION
Added support for MarkAsCurrent of API Versions

* Added validation messages
* Added `IsCurrent` property in `ApiVersion` model